### PR TITLE
add gc_count, total_base_count, and gc_percent to fastq-peek.sh

### DIFF
--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -23,6 +23,23 @@ echo "Processing FASTQ file: $FASTQ_FILE"
 ## Count the number of lines in the FASTQ file
 LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 ## Calculate the number of reads (4 lines per read)
-READ_COUNT=$((LINE_COUNT / 4))
+#READ_COUNT=$((LINE_COUNT / 4))
+READ_COUNT=$(zgrep . $FASTQ_FILE | awk 'NR%4==2{c++} END{ print c }')
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
+
+#Count the number of G and C nucleotides within the input fastq file (GC_COUNT)
+GC_COUNT=$(zgrep . $FASTQ_FILE | awk 'NR%4==2{gsub(/[aAtTnN]/,"");N+=length($0);} END{ print N }')
+echo "Number of GC in $FASTQ_FILE: $GC_COUNT"
+
+#Count the total number of nucleotides within the input fastq file (TOTAL_BASE_COUNT)
+TOTAL_BASE_COUNT=$(zgrep . $FASTQ_FILE | awk 'NR%4==2{l+=length($0)} END{ print l }')
+echo "Number of Nucleotides in $FASTQ_FILE: $TOTAL_BASE_COUNT"
+
+#Calcuate GC content as a percentage: (GC Count / Total Base Count) *100 (GC_PERCENT)
+## requires install of bc
+## apt-get update
+## apt-get install bc
+GC_PERCENT=$(echo "scale=2; ($GC_COUNT/$TOTAL_BASE_COUNT)*100" | bc)
+#To report the GC content, we will print the GC_PERCENT value to stdout, i.e. "GC content in {input_fastq_file}: {GC_PERCENT}%"
+echo "GC content in {$FASTQ_FILE}: {$GC_PERCENT}%"


### PR DESCRIPTION
## Description 

Fastq-peek.sh has been modified to include GC counts, total base counts, and GC percent as was requested in exercise01. GC percent prints to stdout as requested. READ_COUNT was also updated to more closely reflect the output from fastqc results. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

The code changes were tested using three samples; the sample provided in the sandbox, as well as two other openly available fastq files. All files were analyzed using FastQC to obtain base-level (all puns intended) quality scores. Fastq-peek.sh generated results that were concordant with [FastQC](https://hub.docker.com/r/staphb/fastqc).

## Checklist:
- [x] My code adheres to the [repository style guide](https://github.com/theiagen/Mid-Atlantic-SDP4PHB-2025/blob/main/style-guide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes