### PR TITLE
added calculation of percent GC and printing result to stdout

### DIFF
--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -26,3 +26,16 @@ LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 READ_COUNT=$((LINE_COUNT / 4))
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
+
+# Calculate percent GC of all fastq reads in file
+## Confirm processing of sequence line
+#awk 'NR % 4 == 2' $FASTQ_FILE > 'test.out'
+
+## Get total of non-ambiguous bases and total of GC bases
+TOTAL_BASE_COUNT=$(awk 'NR % 4 == 2' "$FASTQ_FILE" | tr -cd 'ACGT' | wc -c)
+GC_COUNT=$(awk 'NR % 4 == 2' "$FASTQ_FILE" | tr -cd 'GC' | wc -c)
+#echo "$TOTAL_BASE_COUNT"
+#echo "$GC_COUNT"
+GC_PERCENT=$(awk "BEGIN {print $GC_COUNT / $TOTAL_BASE_COUNT * 100}")
+
+echo "$FASTQ_FILE GC Content: $GC_PERCENT"


### PR DESCRIPTION
## Description 
Calculated percent GC by counting characters in sequence strings from a fastq. Uses only bash on lines 30-41 of *fastq-peek.sh*

## Type of change
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by recovering correct percentage of 50% from *sample.fq* test data included in repo. Assumes only ACGTN nucleotides are present in fastq files.

## Checklist:
- [X] My code adheres to the [repository style guide](https://github.com/theiagen/Mid-Atlantic-SDP4PHB-2025/blob/main/style-guide.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes