### PR TITLE
adding gc-percentage calculation and reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:  # Define jobs for the workflow
           # Save the expected output to a file
           echo "Processing FASTQ file: ./data/sample.fastq" > expected_output.txt
           echo "Number of reads in ./data/sample.fastq: 2" >> expected_output.txt
+          echo "GC content in ./data/sample.fastq: 50%" >> expected_output.txt
           
           # Capture the actual output of the script and save it to a file
           ./bin/fastq-peek.sh ./data/sample.fastq > actual_output.txt

--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -27,7 +27,7 @@ READ_COUNT=$((LINE_COUNT / 4))
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
 
-# Calculate Percent GC
+# Calculate Percent GC 
 ## Count the number of G and C nucleotides
 GC_COUNT=$(grep -E '^[ATCGN]+$' "$FASTQ_FILE" | tr -cd 'GCgc' | wc -c)
 ## Count the total number of nucleotides (A, T, C, G)

--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -26,3 +26,13 @@ LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 READ_COUNT=$((LINE_COUNT / 4))
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
+
+# Calculate Percent GC
+## Count the number of G and C nucleotides
+GC_COUNT=$(grep -E '^[ATCGN]+$' "$FASTQ_FILE" | tr -cd 'GCgc' | wc -c)
+## Count the total number of nucleotides (A, T, C, G)
+TOTAL_BASE_COUNT=$(grep -E '^[ATCGN]+$' "$FASTQ_FILE" | tr -cd 'ATCGatcg' | wc -c)
+## Calculate the GC content as a percentage
+GC_CONTENT=$(awk "BEGIN {print ($GC_COUNT / $TOTAL_BASE_COUNT) * 100}")
+
+echo "GC content in $FASTQ_FILE: $GC_CONTENT%"


### PR DESCRIPTION
## Description 
fastq-peek.sh now calculates and reports GC-content of the provided fastq file.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

## Checklist:
- [x] My code adheres to the [repository style guide](https://github.com/theiagen/Mid-Atlantic-SDP4PHB-2025/blob/main/style-guide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes