### PR TITLE
Add GC percentage calculation and report to fastq-peek.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:  # Define jobs for the workflow
           # Save the expected output to a file
           echo "Processing FASTQ file: ./data/sample.fastq" > expected_output.txt
           echo "Number of reads in ./data/sample.fastq: 2" >> expected_output.txt
-          
+          echo "GC percentage in ./data/sample.fastq: 50.00%" >> expected_output.txt
+
           # Capture the actual output of the script and save it to a file
           ./bin/fastq-peek.sh ./data/sample.fastq > actual_output.txt
 

--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -26,3 +26,38 @@ LINE_COUNT=$(wc -l < "$FASTQ_FILE")
 READ_COUNT=$((LINE_COUNT / 4))
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
+
+# Count the number of total bases in the FASTQ file 
+for ((i = 1; i <= READ_COUNT; i++)); do 
+    # Extract the second line of each read (the sequence line)
+    READ=$(sed -n "$((i * 4 - 2))p" "$FASTQ_FILE")
+    # Calculate the length of the read
+    READ_LENGTH=${#READ}
+    # Calculate the total number of bases
+    TOTAL_BASE_COUNT=$((TOTAL_BASE_COUNT + READ_LENGTH))
+    # Store the sequence in a variable
+    TOTAL_BASES+="$READ"
+    # Print the length of the sequence
+    #echo "Length of read $i: $READ_LENGTH"
+done
+
+# Print the total number of bases
+#echo "Total bases: $TOTAL_BASE_COUNT"
+
+# Print the complete sequence
+#echo "Complete sequence: $TOTAL_BASES"
+
+# Calculate the number of GC bases in the FASTQ file
+GC_TOTAL=$(echo "$TOTAL_BASES" | grep -o '[GC]' | wc -l)
+
+# Ptint the GC total
+#echo "GC total: $GC_TOTAL"
+
+# Scaled GC total
+GC_SCALED=$((GC_TOTAL * 100))
+
+# Calculate the GC percentage
+GC_PERCENTAGE=$(($GC_SCALED / $TOTAL_BASE_COUNT))
+
+# Report the GC percentage
+echo "GC percentage: $GC_PERCENTAGE%"

--- a/bin/fastq-peek.sh
+++ b/bin/fastq-peek.sh
@@ -27,7 +27,7 @@ READ_COUNT=$((LINE_COUNT / 4))
 
 echo "Number of reads in $FASTQ_FILE: $READ_COUNT"
 
-# Count the number of total bases in the FASTQ file 
+# Count the number of total bases in the FASTQ file and combine all bases into one string
 for ((i = 1; i <= READ_COUNT; i++)); do 
     # Extract the second line of each read (the sequence line)
     READ=$(sed -n "$((i * 4 - 2))p" "$FASTQ_FILE")
@@ -60,4 +60,4 @@ GC_SCALED=$((GC_TOTAL * 100))
 GC_PERCENTAGE=$(($GC_SCALED / $TOTAL_BASE_COUNT))
 
 # Report the GC percentage
-echo "GC percentage: $GC_PERCENTAGE%"
+echo "GC percentage in $FASTQ_FILE: $GC_PERCENTAGE%"


### PR DESCRIPTION
## Description 
Please include a summary of the changes being made within your PR. Please also include relevant motivation and context.

A for loop was added to count the total number of bases ($TOTAL_BASES) and concatenate the reads ($TOTAL_BASE_COUNT). All G and C basecalls in the reads are then  counted ($GC_TOTAL). The GC count is then scaled to prepare for the percentage calculation ($GC_SCALED). The total number of bases and the total number of G and C basecalls are used to calculate the GC percentage of the reads ($GC_PERCENTAGE). This final percentage is reported as "GC percentage: $GC_PERCENTAGE%".

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
A small test data set was used to ensure accurate an GC percentage was calculated. Each step was also printed as it was generated to ensure that the code was accurate. The print commands have been disabled, but not removed.

## Checklist:
-  [x] My code adheres to the [repository style guide](https://github.com/theiagen/Mid-Atlantic-SDP4PHB-2025/blob/main/style-guide.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes